### PR TITLE
Stop triggering workflow for forks, upgrade go version, split go/TypeScript steps

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -3,6 +3,8 @@ on: workflow_call
 jobs:
   comment-coverage-difference:
     runs-on: ubuntu-latest
+    # Check if the event is not triggered by a fork TODO: find a way to manually trigger workflow for forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,10 +17,12 @@ jobs:
         with:
           go-version: '1.17.8'
 
-      - name: Get coverage for caller's PR
+      - name: Get go coverage for caller's PR
         run: |
           go test -v -coverpkg=./... -coverprofile=profile.cov ./...
           echo "go-pr-cov=$(go tool cover -func profile.cov | grep total: | awk '{print substr($NF,1,length($NF)-1)}')" >> $GITHUB_ENV
+      - name: Get TypeScript coverage for caller's PR
+        run: |
           echo "ts-pr-cov=$(yarn test:coverage | grep 'All files' | awk '{print $10}')" >> $GITHUB_ENV
 
       - uses: actions/checkout@v3
@@ -29,10 +31,13 @@ jobs:
       - name: yarn install for caller's main
         run: yarn install
 
-      - name: Get coverage on caller's main
+      - name: Get go coverage on caller's main
         run: |
           go test -v -coverpkg=./... -coverprofile=profile.cov ./...
           echo "go-main-cov=$(go tool cover -func profile.cov | grep total: | awk '{print substr($NF,1,length($NF)-1)}')" >> $GITHUB_ENV
+
+      - name: Get TypeScript coverage on caller's main
+        run: |
           echo "ts-main-cov=$(yarn test:coverage | grep 'All files' | awk '{print $10}')" >> $GITHUB_ENV
 
       - name: Calculate coverage difference

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -15,7 +15,7 @@ jobs:
         run: yarn install
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.1'
+          go-version: '1.17.8'
 
       - name: Get coverage for caller's PR
         run: |


### PR DESCRIPTION
- Split steps for go and TypeScript in order to get more granular timing information
- Change to go 1.17.8
- Stop triggering workflow for forks

This will skip the workflow for external PRs (created from forks), see #1 