### PR TITLE
chore: update go version to 1.18.7

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn install
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.8"
+          go-version: "1.18.7"
       - name: generate go for github.com/grafana/grafana
         if: github.repository == 'grafana/grafana'
         run: make gen-go


### PR DESCRIPTION
we've noticed some failures on coverage actions which i believe are related to the use of generics in go. updating to 1.18.x (as per `go.mod` in the grafana repo) should fix them