### PR TITLE
Downgrade to node 16 to support all nested dependencies

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 17.x
+          node-version: 16.x
           cache: yarn
       - name: yarn install for caller's PR
         run: yarn install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 #### TypeScript
 * yarn
 * package.json must contain a script `yarn test:coverage` which generates a report in `"jest --coverage"` style
-* runs in node 17.x environment
+* runs in node 16.x environment
 
 ## Description
 


### PR DESCRIPTION
Upgrading reopos that use this repo to run test in drone revealed mismatches of required node versions. Some exclude 17 and others only support <=17. 
In order to support all of them, we're downgrading the step to use node 16.x, since that is the lowest common required version for our dependencies.