### PR TITLE
Update workflow to skip install and gen steps

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -33,13 +33,26 @@ jobs:
           node-version: 16.x
           cache: yarn
       - name: yarn install for caller's PR
-        run: yarn install
+        run: | 
+        PATHS=(${{ steps.relevant-paths.outputs.frontend-paths }})
+        if [ -z "$PATHS" ]; then
+            echo "No frontend paths to check"
+            exit 0
+        else
+          yarn install
+
       - uses: actions/setup-go@v2
         with:
           go-version: "1.19"
       - name: generate go for github.com/grafana/grafana
         if: github.repository == 'grafana/grafana'
-        run: make gen-go
+        run: |
+        PATHS=(${{ steps.relevant-paths.outputs.backend-paths }})
+        if [ -z "$PATHS" ]; then
+            echo "No backend paths to check"
+            exit 0
+        else
+          make gen-go
 
       - name: Get go coverage for caller's PR
         id: pr-backend
@@ -113,11 +126,25 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: main
+
       - name: yarn install for caller's main
-        run: yarn install
+        run: |
+        PATHS=(${{ steps.relevant-paths.outputs.frontend-paths }})
+        if [ -z "$PATHS" ]; then
+            echo "No frontend paths to check"
+            exit 0
+        else
+          yarn install
+
       - name: generate go for github.com/grafana/grafana
         if: github.repository == 'grafana/grafana'
-        run: make gen-go
+        run: |
+        PATHS=(${{ steps.relevant-paths.outputs.backend-paths }})
+        if [ -z "$PATHS" ]; then
+            echo "No backend paths to check"
+            exit 0
+        else
+          make gen-go
 
       - name: Get go coverage on caller's main
         id: main-backend
@@ -149,6 +176,7 @@ jobs:
               done
               echo "::set-output name=coverage::$(echo -e $PLUGIN_COVERAGE)"
           fi
+      
       - name: Get TypeScript coverage on caller's main
         id: main-frontend
         run: |
@@ -194,6 +222,7 @@ jobs:
           path: |
             backend_coverage_main
             backend_coverage_pr
+     
       - name: Archive frontend code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -269,6 +298,7 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: |
             Backend code coverage report for PR #${{ github.event.pull_request.number }}
+     
       - name: Find previous frontend comment, if any
         uses: peter-evans/find-comment@v2
         id: find-frontend-comment
@@ -287,6 +317,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.comments.outputs.backend-comment }}
           edit-mode: replace
+      
       - name: Create or update frontend comment
         uses: peter-evans/create-or-update-comment@v2
         # Check if the event is not triggered by a fork


### PR DESCRIPTION
- If there are no backend/frontend paths then we should skip the yarn install and gen-go steps to save time