### PR TITLE
Bump Go version used by comment-coverage-difference to 1.20.x

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.20.x"
       - name: generate go for github.com/grafana/grafana
         if: github.repository == 'grafana/grafana'
         run: |


### PR DESCRIPTION
Fixes failing CI job in https://github.com/grafana/grafana/pull/71888 (and possibly others). Bumps Go to `1.20.x`.