### PR TITLE
Use node 18.x and golang 1.21.x

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
       - name: yarn install for caller's PR
         run: |
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
       - name: generate go for github.com/grafana/grafana
         if: github.repository == 'grafana/grafana'
         run: |


### PR DESCRIPTION
This PR bumps node and golang versions -- seems to be required for https://github.com/grafana/grafana/pull/77304

https://github.com/grafana/grafana/actions/runs/6711118369/job/18237777023?pr=77304
<img width="1301" alt="image" src="https://github.com/grafana/code-coverage/assets/705951/7c2c6d85-c23b-4d41-a326-a564b76e3da5">
